### PR TITLE
Updates the circle style when percent prop changes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,6 @@
 **/
 import React, { Component } from 'react';
 
-const styles = require('style-loader!css-loader!./style.css');
-
 class ReactjsPercentageCircle extends Component {
   constructor(props) {
     super(props);

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,27 @@ class ReactjsPercentageCircle extends Component {
       rightTransformerDegree: rightTransformerDegree,
     };
   }
+
+  componentDidUpdate(prevProps){
+    if(prevProps.percent != this.state.percent){
+      const percent = this.props.percent;
+      let leftTransformerDegree = '0deg';
+      let rightTransformerDegree = '0deg';
+      if (percent >= 50) {
+        rightTransformerDegree = '180deg';
+        leftTransformerDegree = (percent - 50) * 3.6 + 'deg';
+      } else {
+        rightTransformerDegree = percent * 3.6 + 'deg';
+        leftTransformerDegree = '0deg';
+      }
+      this.setState({
+        percent: this.props.percent,
+        leftTransformerDegree: leftTransformerDegree,
+        rightTransformerDegree: rightTransformerDegree,
+      });
+    }
+  }
+  
   render() {
     return (
       <div

--- a/src/style.css
+++ b/src/style.css
@@ -19,6 +19,7 @@
   left:0;
   top:0;
   border-radius:1000;
+  transition: transform .25s ease;
   transform-origin: 0 50%;
 }
 .loader2{
@@ -26,6 +27,7 @@
   left:0;
   top:0;
   border-radius:1000;
+  transition: transform .25s ease;
   transform-origin: 100% 50%;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -2,6 +2,7 @@
   overflow: hidden;
   position: relative;
   background-color:#e3e3e3;
+  z-index: 1;
 }
 .left-wrap{
   overflow: hidden;
@@ -19,7 +20,7 @@
   left:0;
   top:0;
   border-radius:1000;
-  transition: transform .25s ease;
+  transition: transform .1s linear;
   transform-origin: 0 50%;
 }
 .loader2{
@@ -27,7 +28,7 @@
   left:0;
   top:0;
   border-radius:1000;
-  transition: transform .25s ease;
+  transition: transform .1s linear;
   transform-origin: 100% 50%;
 }
 


### PR DESCRIPTION
When the percent prop changes, the circle border does not update. This PR updates the border when the percent changes, and applies a transition.

This is my component. It animates from 0 to the `maxPercent` prop when scrolled into view.

    import scrollTrack from 'scroll-track';
    import React from 'react';
    import ReactDOM from 'react-dom';
    import PercentageCircle from 'reactjs-percentage-circle';

    class StatisticCircle extends React.Component {
      constructor(props){
        super(props);
        this.myRef = React.createRef();
        this.state = {
          percent: 0
        }
      }

      componentDidMount(){
        const context = this;
        const tracker = scrollTrack.create(this.myRef.current);
        tracker.on('enter-viewport', () => {
          const incrementAnimation = setInterval(function(){
            if(context.state.percent != context.props.maxPercent){
                context.setState({
                  percent: context.state.percent + 1
                });
            } else {
              clearInterval(incrementAnimation);
            }
          }, 2000 / context.props.maxPercent);
        });
      }

      render() {

        const { percent } = this.state;

        return (
          <div ref={this.myRef}>
            <PercentageCircle
              percent={percent}
              color={'#f6684c'}
              bgcolor={'#eaf3f8'}
              radius={80}
              borderWidth={20}
              textStyle={{ fontSize: '2em' }}
            />
          </div>
        );
      }

    }
